### PR TITLE
Support for X-Aws-Sqsd-Attr-* in the request headers.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM vivareal/base-images:alpine-3.5-java-8-jdk
+FROM java:8-jdk-alpine
 MAINTAINER Alexandre Silva (alexandre.silva@gzvr.com.br)
 
 COPY ./target/universal/aws-sqsd-0.1.tgz /usr/local/app/aws-sqsd-0.1.tgz
@@ -7,6 +7,7 @@ WORKDIR /usr/local/app
 
 RUN tar xf aws-sqsd-0.1.tgz
 RUN rm aws-sqsd-0.1.tgz
+RUN apk add --no-cache bash
 
 WORKDIR /usr/local/app/aws-sqsd-0.1
 

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1,5 +1,6 @@
 akka {
   loglevel = "DEBUG"
+  loglevel = ${?LOG_LEVEL}
 
   # Comment this line if you want to see the real dispatcher being used
   # This will only be possible changing the pattern into logback file
@@ -45,7 +46,7 @@ app {
 
 akka.http.client {
   connecting-timeout = 3s
-  idle-timeout = 30s
+  idle-timeout = ${?SQSD_WORKER_TIMEOUT}ms
 }
 
 http-dispatcher {

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1,7 +1,8 @@
 akka {
   loglevel = "DEBUG"
   loglevel = ${?LOG_LEVEL}
-
+  logger-startup-timeout = 30s
+  
   # Comment this line if you want to see the real dispatcher being used
   # This will only be possible changing the pattern into logback file
   loggers = ["akka.event.slf4j.Slf4jLogger"]


### PR DESCRIPTION
---
X-Aws-Sqsd-Attr-message-attribute-name

Custom message attributes assigned to the message being processed. The message-attribute-name is the actual message attribute name. All string and number message attributes are added to the header. Binary attributes are discarded and not included in the header.